### PR TITLE
add inspect; other updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Hex.pm Version](https://img.shields.io/hexpm/v/tim.svg)](https://hex.pm/packages/tim)
+[![Version][hex-pm-version-badge]][hex-pm-versions]
+
+<!-- END HEADER -->
 
 _`Tim` the tiny timer._
 
@@ -12,15 +14,11 @@ evaluated expression, and the expression's string representation. To use
 `time`, require or import `Tim` into your environment and pipe in the expression:
 
 ```elixir
-require Tim
-
-1..10 
-|> Enum.map(& &1 * 2/((1 + 10) * 10)) 
-|> Enum.sum() 
-|> Tim.time()
-
-# returns (actual timing numbers will vary)
-
+iex> require Tim
+iex> 1..10 
+...> |> Enum.map(& &1 * 2/((1 + 10) * 10)) 
+...> |> Enum.sum()
+...> |> Tim.time()
 %{
   expr: "1..10 |> Enum.map(&(&1 * 2 / ((1 + 10) * 10))) |> Enum.sum()",
   max: 46,
@@ -28,25 +26,35 @@ require Tim
   median: 46,
   min: 46,
   n: 1,
-  result: 1.0
+  result: 1.0,
+  unit: :microsecond
 }
 ```
-All times are in microseconds.
+Actual timing statistics will vary. By default, all times are in microseconds.
 
-The `time` macro takes a second argument that is the number `n` of times the expression
-is executed to gather timing statistics. When the above expression is piped into
-`Time.time(100)`, the result will look something like
+The `time` macro has two optional keyword arguments: 
+* `:n` - number of times 
+the expression is executed to gather timing statistics (defaults to 1)
+* `:unit` - unit of time in the reported statistics, which can be one of `:microsecond` (default), `:millisecond`, `:second`, `:minute`, or `:hour`
+
+`Tim` also provides an `inspect` macro that applies `IO.inspect` to the timing data returned
+by `Tim.time`, but then returns the result of the expression being timed. This allows timing 
+data to be captured in the middle of a pipeline. Like `Tim.time`, `inspect` also takes the
+optional keyword arguments `:n` and `:unit`. Here's an example of using `inspect`:
 
 ```elixir
-%{
-  expr: "1..10 |> Enum.map(&(&1 * 2 / ((1 + 10) * 10))) |> Enum.sum()",
-  max: 71,
-  mean: 13.83,
-  median: 12,
-  min: 10,
-  n: 100,
-  result: 1.0
+iex> require Tim
+iex> :timer.sleep(1_000) |> Tim.inspect(n: 2, unit: :second)
+Timing data: %{
+  max: 1.000952,
+  min: 1.00057,
+  unit: :second,
+  expr: ":timer.sleep(1000)",
+  n: 2,
+  mean: 1.000761,
+  median: 1.000952
 }
+:ok
 ```
 
 ## Under the hood

--- a/lib/stats.ex
+++ b/lib/stats.ex
@@ -6,14 +6,15 @@ defmodule Tim.Stats do
   @doc """
   Return a map of statistical aggregates for a list of numbers.
   """
-  @spec collect(list(number)) :: map
-  def collect(list) do
+  @spec collect([number, ...], number) :: %{atom => number}
+  def collect(nums, scale) do
     %{
-      mean: mean(list),
-      median: median(list),
-      min: min(list),
-      max: max(list)
+      mean: mean(nums),
+      median: median(nums),
+      min: min(nums),
+      max: max(nums)
     }
+    |> apply_scale(scale)
   end
 
   @doc """
@@ -26,6 +27,7 @@ defmodule Tim.Stats do
       iex> Tim.Stats.mean([1, 2, 3, 4])
       2.5
   """
+  @spec mean([number, ...]) :: number
   def mean([_ | _] = list), do: Enum.sum(list) / length(list)
   def mean([]), do: handle_empty()
 
@@ -42,6 +44,7 @@ defmodule Tim.Stats do
       iex> Tim.Stats.median([1, 2, 3, 4])
       3
   """
+  @spec median([number, ...]) :: number
   def median([_ | _] = list) do
     sorted = Enum.sort(list)
     len = length(list)
@@ -58,12 +61,19 @@ defmodule Tim.Stats do
   @doc """
   Compute the minimum value of a list of numbers. This aliases `Enum.min`.
   """
+  @spec min([number, ...]) :: number
   def min(list), do: Enum.min(list)
 
   @doc """
   Compute the maximum value of a list of numbers. This aliases `Enum.max`.
   """
+  @spec max([number, ...]) :: number
   def max(list), do: Enum.max(list)
+
+  @spec apply_scale(%{atom => number}, number) :: %{atom => number}
+  defp apply_scale(stats, scale) do
+    for {k, v} <- stats, into: %{}, do: {k, v * scale}
+  end
 
   defp handle_empty(), do: raise(Enum.EmptyError)
 end

--- a/lib/tim.ex
+++ b/lib/tim.ex
@@ -1,58 +1,32 @@
 defmodule Tim do
+  @readme "README.md"
+  @external_resource @readme
+  @moduledoc_readme @readme
+                    |> File.read!()
+                    |> String.split("<!-- END HEADER -->")
+                    |> Enum.fetch!(1)
+                    |> String.trim()
+
   @moduledoc """
-  `Tim` provides the macro `time` that takes any valid Elixir expression and returns a map
-  containing several statistics for the expression's execution time, the result of the
-  evaluated expression, and the expression's string representation. To use
-  `time`, require or import `Tim` into your environment and pipe in the expression:
-
-  ```elixir
-  require Tim
-
-  1..10
-  |> Enum.map(& &1 * 2/((1 + 10) * 10))
-  |> Enum.sum()
-  |> Tim.time()
-  ```
-
-  This returns (actual timing numbers will vary)
-
-  ```elixir
-  %{
-    expr: "1..10 |> Enum.map(&(&1 * 2 / ((1 + 10) * 10))) |> Enum.sum()",
-    max: 46,
-    mean: 46.0,
-    median: 46,a
-    min: 46,
-    n: 1,
-    result: 1.0
-  }
-  ```
-  All times are in microseconds.
-
-  The `time` macro takes a second argument that is the number `n` of times the expression
-  is executed to gather timing statistics. When the above expression is piped into
-  `Time.time(100)`, the result will look something like
-
-  ```elixir
-  %{
-    expr: "1..10 |> Enum.map(&(&1 * 2 / ((1 + 10) * 10))) |> Enum.sum()",
-    max: 71,
-    mean: 13.83,
-    median: 12,
-    min: 10,
-    n: 100,
-    result: 1.0
-  }
-  ```
+  #{@moduledoc_readme}
   """
 
   alias Tim.Stats
 
+  @type unit :: :microsecond | :millisecond | :second | :minute | :hour
+
+  @default_opts %{n: 1, unit: :microsecond}
+
   @doc """
-  Takes an Elixir expression and returns a map of timing stats after executing
-  the provided expression `n` times.
+  Takes an Elixir expression and returns a map of timing stats and the evaluated result.
+
+  `time` has the following optional keyword arguments:
+  * `:n` - number of times the expression is evaluated to build statistics; defaults to 1
+  * `:unit` - unit of time for the timing statistics; `:microsecond` (default) | `:millisecond` | `:second` | `:minute` | `:hour`
   """
-  defmacro time(expr, n \\ 1) when is_integer(n) do
+  defmacro time(expr, opts \\ []) do
+    %{n: n, unit: unit} = Map.merge(@default_opts, Enum.into(opts, %{}))
+    scale = unit_to_scale(unit)
     expr_string = Macro.to_string(expr)
 
     quote do
@@ -63,9 +37,34 @@ defmodule Tim do
         |> Enum.unzip()
 
       Map.merge(
-        %{expr: unquote(expr_string), n: unquote(n), result: result},
-        Stats.collect(times)
+        %{expr: unquote(expr_string), n: unquote(n), result: result, unit: unquote(unit)},
+        Stats.collect(times, unquote(scale))
       )
     end
   end
+
+  @doc """
+  Takes an Elixir expression and returns the evaluated result while also
+  applying `IO.inspect` to the map of timing stats.
+
+  `inspect` has the following optional keyword arguments:
+  * `:n` - number of times the expression is evaluated to build statistics; defaults to 1
+  * `:unit` - unit of time for the timing statistics; `:microsecond` (default) | `:millisecond` | `:second` | `:minute` | `:hour`
+  """
+  defmacro inspect(expr, opts \\ []) do
+    quote do
+      unquote(expr)
+      |> Tim.time(unquote(opts))
+      |> then(fn %{result: result} = data ->
+        data |> Map.delete(:result) |> IO.inspect(label: "Timing data")
+        result
+      end)
+    end
+  end
+
+  defp unit_to_scale(:microsecond), do: 1
+  defp unit_to_scale(:millisecond), do: 1.0e-3
+  defp unit_to_scale(:second), do: 1.0e-6
+  defp unit_to_scale(:minute), do: 1.6667e-8
+  defp unit_to_scale(:hour), do: 2.7778e-10
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,14 +1,14 @@
 defmodule Tim.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.2.0"
 
   def project do
     [
       app: :tim,
       name: "Tim",
       version: @version,
-      elixir: "~> 1.14",
+      elixir: "~> 1.15",
       description: description(),
       package: package(),
       docs: docs(),
@@ -31,7 +31,7 @@ defmodule Tim.MixProject do
   end
 
   defp description() do
-    "Tim provides a macro for measuring the execution time of an arbitrary Elixir expression."
+    "Tim provides macros for measuring the execution time of an arbitrary Elixir expression."
   end
 
   defp package() do

--- a/test/stats_test.exs
+++ b/test/stats_test.exs
@@ -3,12 +3,12 @@ defmodule StatsTest do
   doctest Tim.Stats
 
   test "collect stats nonempty" do
-    c = Tim.Stats.collect([1, 2, 3])
+    c = Tim.Stats.collect([1, 2, 3], 1)
 
     assert c == %{mean: 2.0, median: 2, min: 1, max: 3}
   end
 
   test "collect stats empty exception" do
-    assert_raise(Enum.EmptyError, fn -> Tim.Stats.collect([]) end)
+    assert_raise(Enum.EmptyError, fn -> Tim.Stats.collect([], 1) end)
   end
 end

--- a/test/tim_test.exs
+++ b/test/tim_test.exs
@@ -1,16 +1,41 @@
 defmodule TimTest do
   use ExUnit.Case
-  doctest Tim
+  require Tim
 
-  test "sleep, test result and mean" do
+  test "time sleep, test result and mean" do
     map =
       :timer.sleep(1)
       |> case do
         :ok -> 1
       end
-      |> Tim.time(10)
+      |> Tim.time(n: 10)
 
     assert map.result == 1
-    assert map.mean <= 3_000
+    assert map.mean < 3_000
+  end
+
+  test "inspect sleep, check result" do
+    sleeper = fn ->
+      :timer.sleep(1)
+      "test"
+    end
+
+    result =
+      sleeper.()
+      |> Tim.inspect()
+
+    assert result == "test"
+  end
+
+  test "time sleep with unit" do
+    map =
+      :timer.sleep(1)
+      |> case do
+        :ok -> 1
+      end
+      |> Tim.time(n: 10, unit: :millisecond)
+
+    assert map.result == 1
+    assert map.mean < 3
   end
 end


### PR DESCRIPTION
Adds `inspect` macro, which is similar to `time`, but only inspects the timing map and returns the result of the expression. 

Both `time` and `inspect` now take optional keyword args that include `:n`, the iteration count, and `:unit`, the time unit used for timing stats.

Docs and tests have been updated.